### PR TITLE
Intentionally fail spec

### DIFF
--- a/spec/robot_spec.rb
+++ b/spec/robot_spec.rb
@@ -17,7 +17,7 @@ describe Robot do
     context 'with invalid x' do
       let(:x) { 5 }
 
-      it { is_expected.to eq '0,0,' }
+      it { is_expected.to eq '1,0,' }
     end
 
     context 'with invalid y' do


### PR DESCRIPTION
Intentionally add a failing spec to test the `ruby` github action.